### PR TITLE
Fix: Item Hide/Unhide

### DIFF
--- a/apps/librarian/lib/core/api/models/item_model.dart
+++ b/apps/librarian/lib/core/api/models/item_model.dart
@@ -33,6 +33,11 @@ class ItemModel {
   final List<String> imageUrls;
   final List<ManualModel> manuals;
 
+  // TECH DEBT - Will be replaced by a location system in the future.
+  bool get isManagedByPartner {
+    return location == 'Providence Public Library';
+  }
+
   factory ItemModel.fromJson(Map<String, dynamic> json) {
     return ItemModel(
       id: json['id'] as String,

--- a/apps/librarian/lib/modules/things/details/inventory/icons.dart
+++ b/apps/librarian/lib/modules/things/details/inventory/icons.dart
@@ -26,7 +26,7 @@ Widget getIcon(ItemModel item) {
     return hiddenIcon;
   }
 
-  if (item.location == 'Providence Public Library') {
+  if (item.isManagedByPartner) {
     return partnerLocationIcon;
   }
 

--- a/apps/librarian/lib/modules/things/details/inventory/item_details/drawer.dart
+++ b/apps/librarian/lib/modules/things/details/inventory/item_details/drawer.dart
@@ -75,7 +75,7 @@ class _ItemDetailsDrawerState extends State<ItemDetailsDrawer> {
                         ItemDetails(
                           controller: widget.controller,
                           item: widget.controller.item!,
-                          hiddenLocked: widget.isHiddenLocked,
+                          isThingHidden: widget.isHiddenLocked,
                         ),
                         const SizedBox(height: 80),
                       ],

--- a/apps/librarian/lib/modules/things/details/inventory/item_details/item_details.dart
+++ b/apps/librarian/lib/modules/things/details/inventory/item_details/item_details.dart
@@ -14,12 +14,12 @@ class ItemDetails extends ConsumerWidget {
     super.key,
     required this.controller,
     required this.item,
-    required this.hiddenLocked,
+    required this.isThingHidden,
   });
 
   final ItemDetailsController controller;
   final ItemModel item;
-  final bool hiddenLocked;
+  final bool isThingHidden;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -43,27 +43,12 @@ class ItemDetails extends ConsumerWidget {
               clipBehavior: Clip.antiAlias,
               elevation: isMobile(context) ? 1 : 0,
               margin: EdgeInsets.zero,
-              child: Builder(
-                builder: (context) {
-                  final newCheckbox = CheckboxListTile(
-                    title: const Text('Hidden'),
-                    secondary: const Icon(Icons.visibility_off_outlined),
-                    value: controller.hiddenNotifier.value,
-                    onChanged: hiddenLocked
-                        ? null
-                        : (value) {
-                            controller.hiddenNotifier.value = value ?? false;
-                          },
-                  );
-
-                  if (!hiddenLocked) {
-                    return newCheckbox;
-                  }
-
-                  return Tooltip(
-                    message: 'Unable to unhide because the thing is hidden.',
-                    child: newCheckbox,
-                  );
+              child: _HiddenCheckboxListTile(
+                isThingHidden: isThingHidden,
+                isManagedByPartner: item.isManagedByPartner,
+                value: controller.hiddenNotifier.value,
+                onChanged: (value) {
+                  controller.hiddenNotifier.value = value ?? false;
                 },
               ),
             ),
@@ -192,6 +177,58 @@ class ItemDetails extends ConsumerWidget {
               },
             ),
           ],
+        );
+      },
+    );
+  }
+}
+
+class _HiddenCheckboxListTile extends StatelessWidget {
+  const _HiddenCheckboxListTile({
+    required this.isThingHidden,
+    required this.isManagedByPartner,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final bool isThingHidden;
+  final bool isManagedByPartner;
+  final bool? value;
+  final void Function(bool?) onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (context) {
+        if (isThingHidden) {
+          return const CheckboxListTile(
+            title: Text('Hidden'),
+            subtitle:
+                Text('Unable to unhide because the parent thing is hidden.'),
+            secondary: Icon(Icons.visibility_off_outlined),
+            value: true,
+            onChanged: null,
+          );
+        }
+
+        if (isManagedByPartner) {
+          return const CheckboxListTile(
+            title: Text('Hidden'),
+            subtitle: Text(
+                'Unable to unhide because this item is at a partner location.'),
+            secondary: Icon(Icons.visibility_off_outlined),
+            value: true,
+            onChanged: null,
+          );
+        }
+
+        return CheckboxListTile(
+          title: const Text('Hidden'),
+          secondary: value == true
+              ? const Icon(Icons.visibility_off_outlined)
+              : const Icon(Icons.visibility_outlined),
+          value: value,
+          onChanged: onChanged,
         );
       },
     );

--- a/apps/librarian/lib/modules/things/details/inventory/item_details_page.dart
+++ b/apps/librarian/lib/modules/things/details/inventory/item_details_page.dart
@@ -38,7 +38,7 @@ class _ItemDetailsPageState extends ConsumerState<ItemDetailsPage> {
           child: ItemDetails(
             controller: _controller,
             item: widget.item,
-            hiddenLocked: widget.hiddenLocked,
+            isThingHidden: widget.hiddenLocked,
           ),
         ),
       ),

--- a/apps/librarian/lib/modules/things/details/inventory_details.dart
+++ b/apps/librarian/lib/modules/things/details/inventory_details.dart
@@ -98,10 +98,12 @@ class InventoryDetails extends ConsumerWidget {
                 );
 
                 ref.read(endDrawerProvider).openEndDrawer(
-                    context,
-                    ItemDetailsDrawer(
-                      controller: detailsController,
-                    ));
+                      context,
+                      ItemDetailsDrawer(
+                        controller: detailsController,
+                        isHiddenLocked: details.hidden,
+                      ),
+                    );
               },
               onAddItemsPressed: () {
                 showDialog(


### PR DESCRIPTION
## Changes
- Fixes a bug which would allow the user to uncheck the Hidden field, even though the parent thing is hidden.
- Adds contextual clues to the hidden field to explain why an item can't be unhidden.